### PR TITLE
test: 환율 조회 Provider Test 외부 API 호출이 아닌 Mock 객체를 응답받도록 수정 / #52

### DIFF
--- a/src/test/java/org/creditto/core_banking/domain/exchange/ExchangeRateProviderTest.java
+++ b/src/test/java/org/creditto/core_banking/domain/exchange/ExchangeRateProviderTest.java
@@ -1,43 +1,67 @@
 package org.creditto.core_banking.domain.exchange;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.creditto.core_banking.domain.exchange.dto.ExchangeRateRes;
+import org.creditto.core_banking.global.feign.ExchangeRateFeign;
 import org.creditto.core_banking.global.feign.ExchangeRateProvider;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 class ExchangeRateProviderTest {
 
-    @Autowired
+    @Mock
+    private ExchangeRateFeign exchangeRateFeign;
+
+    @InjectMocks
     private ExchangeRateProvider exchangeRateProvider;
 
-    @Autowired
-    private ObjectMapper objectMapper; // JSON 출력을 위해 ObjectMapper 주입
+    @BeforeEach
+    void setUp() {
+        // wire test auth key since @Value won't run without Spring context
+        ReflectionTestUtils.setField(exchangeRateProvider, "authkey", "test-key");
+    }
 
     @Test
     @DisplayName("외부 환율 API 호출 및 데이터 수신 테스트")
     void getExchangeRates_APICall_Success() {
-        // when: ExchangeRateProvider를 통해 실제 외부 API 호출
+        List<ExchangeRateRes> mockedRates = List.of(
+                ExchangeRateRes.builder()
+                        .currencyUnit("USD")
+                        .baseRate("1300.00")
+                        .currencyName("미국 달러")
+                        .build(),
+                ExchangeRateRes.builder()
+                        .currencyUnit("EUR")
+                        .baseRate("1400.00")
+                        .currencyName("유로")
+                        .build()
+        );
+
+        // when: 외부 API 호출 대신 Mocked FeignClient 응답 사용
+        given(exchangeRateFeign.getExchangeRate(anyString(), anyString(), eq("AP01")))
+                .willReturn(mockedRates);
+
         Map<String, ExchangeRateRes> rates = exchangeRateProvider.getExchangeRates();
 
-        assertThat(rates).isNotNull().isNotEmpty();
-
-        System.out.println("Successfully fetched " + rates.size() + " exchange rates.");
-        rates.values().forEach(rate -> {
-            try {
-                // 각 환율 정보를 보기 좋은 JSON 형태로 출력
-                System.out.println(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(rate));
-            } catch (JsonProcessingException e) {
-                System.out.println("Error printing rate object: " + e.getMessage());
-            }
-        });
+        assertThat(rates)
+                .isNotNull()
+                .hasSize(mockedRates.size())
+                .containsKeys("USD", "EUR");
+        assertThat(rates.get("USD").getBaseRate()).isEqualTo("1300.00");
+        assertThat(rates.get("EUR").getCurrencyName()).isEqualTo("유로");
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -3,10 +3,10 @@ spring:
     name: core-banking
 
   datasource:
-    url: jdbc:mysql://${DB_URL}/${DATABASE_NAME}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
 
   jpa:
     hibernate:
@@ -16,7 +16,7 @@ spring:
         dialect: org.hibernate.dialect.H2Dialect
 
 exchange:
-  auth-key: ${EX_API_KEY}
+  auth-key: test-key
 
 scheduler:
   remittance:


### PR DESCRIPTION
## 🗞️ 연관된 이슈

### 🔥 이슈번호
- *Resolved* : #52 

## ✅ 작업 내용

- 환율 조회 Provider Test 외부 API 호출이 아닌 Mock 객체를 응답받도록 수정

### 📸 스크린샷 (선택)

## 체크리스트 ✅
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [ ] 테스트 코드를 작성하셨나요?

## 기타
